### PR TITLE
Refactor: Use Capacitor for Android app

### DIFF
--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -1,0 +1,30 @@
+import type { CapacitorConfig } from '@capacitor/core';
+
+const config: CapacitorConfig = {
+  appId: 'app.lovable.994cfffa0d8e4a948c58725d5a05f780',
+  appName: 'card-clash-legends-arena',
+  webDir: 'dist',
+  server: {
+    url: "https://994cfffa-0d8e-4a94-8c58-725d5a05f780.lovableproject.com?forceHideBadge=true",
+    cleartext: true
+  },
+  plugins: {
+    SplashScreen: {
+      launchShowDuration: 3000,
+      launchAutoHide: true,
+      backgroundColor: "#1a1a1a",
+      androidSplashResourceName: "splash",
+      androidScaleType: "CENTER_CROP",
+      showSpinner: false,
+      androidSpinnerStyle: "large",
+      iosSpinnerStyle: "small",
+      spinnerColor: "#999999",
+      splashFullScreen: true,
+      splashImmersive: true,
+      layoutName: "launch_screen",
+      useDialog: true,
+    },
+  },
+};
+
+export default config;


### PR DESCRIPTION
Update the repository to use Capacitor for building an Android app. Provide detailed instructions for cloning the repository, testing the app locally, and making changes.